### PR TITLE
Fixed fake--em--dashes

### DIFF
--- a/src/behaviors/karma/karma.js
+++ b/src/behaviors/karma/karma.js
@@ -1,9 +1,9 @@
 import Behavior from '../behavior.js';
 import Karma from './models/karma.js';
 
-const USER_KARMA_REGEX = /<@(\w+)(?:\|\w+)?>(?:[\s\:]*)(\+\+|\-\-)(?:\s?(?:#|\/\/)\s?((?:[\s\S])+))?/gi,
+const USER_KARMA_REGEX = /<@(\w+)(?:\|\w+)?>(?:[\s\:]*)(\+\+|\-\-)(?:\s+|$)(?:(?:#|\/\/)\s?((?:[\s\S])+))?/gi,
   USER_REGEX = /<@(\w+)>/gi,
-  THING_KARMA_REGEX = /((?:\w+)|["|“|”](?:[\s\S]+)["|“|”])(\+\+|\-\-)(?:\s?(?:#|\/\/)\s?((?:[\s\S])+))?/gi,
+  THING_KARMA_REGEX = /((?:\w+)|["|“|”](?:[\s\S]+)["|“|”])(\+\+|\-\-)(?:\s+|$)(?:(?:#|\/\/)\s?((?:[\s\S])+))?/gi,
   THING_REGEX = /!explain ((?:\w+)|["|“|”](?:[\s\S]+)["|“|”])/gi,
   LIST_REGEX = /^!(?:top|bottom) (thing|person)/gi;
 


### PR DESCRIPTION
Tested briefly in a web browser, but beyond that not tested in practice; some verification would be nice, but it seems to work :)

The major fix is the `(?:\s+|$)` group after the `++` or `--`--the meaning of which is that "an operator must be followed by at least one whitespace character, or by the end of the message". It absorbed a previous "\s?" group used to separate the comment character (`//` or `#`) out. In practice, that means the following are legal:

- `foo++ #being a bar`
- `<@blah>--`
- `But definitely whiz++ for being a bang`

...the following, however, are not:

- `But--as you can see...`
- `spang++whammo #thwonk`

Suggestions welcome! :D